### PR TITLE
fix: Akira-PapaからT3taへのベースアクション参照の更新

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,17 +18,17 @@ jobs:
           fetch-depth: 1
 
       - name: Auto review PR
-        uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+        uses: t3ta/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: Use OAuth for Claude Max subscribers (ACTIVE)
           use_oauth: "true"
           claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
           claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
           claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          
+
           direct_prompt: |
             Please review this PR. Look at the changes and provide thoughtful feedback on:
             - Code quality and best practices

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: Akira-Papa/claude-code-action@beta
+        uses: t3ta/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: Use OAuth for Claude Max subscribers (ACTIVE)
           use_oauth: "true"
           claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Fork Changes (Akira-Papa/claude-code-action@beta)
+## Fork Changes (t3ta/claude-code-action)
 
 This is a fork of the official Claude Code Action that adds OAuth authentication support for Claude Max subscribers.
 
@@ -11,7 +11,7 @@ This is a fork of the official Claude Code Action that adds OAuth authentication
   - New input: `claude_access_token` - OAuth access token from Claude Max subscription
   - New input: `claude_refresh_token` - OAuth refresh token from Claude Max subscription
   - New input: `claude_expires_at` - Token expiration timestamp
-- **Updated Base Action**: Uses `Akira-Papa/claude-code-base-action@beta` which includes OAuth credential handling
+- **Updated Base Action**: Uses `t3ta/claude-code-base-action@main` which includes OAuth credential handling
 
 ### Changed
 
@@ -28,7 +28,7 @@ This is a fork of the official Claude Code Action that adds OAuth authentication
    - `CLAUDE_EXPIRES_AT`
 3. Enable OAuth in your workflow:
    ```yaml
-   - uses: Akira-Papa/claude-code-action@beta
+   - uses: t3ta/claude-code-action@main
      with:
        use_oauth: "true"
        claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
@@ -38,4 +38,4 @@ This is a fork of the official Claude Code Action that adds OAuth authentication
 
 ### Compatibility
 
-This fork maintains full backward compatibility with the original action. All existing workflows will continue to work without changes. OAuth is an optional authentication method alongside the existing options (API key, Bedrock, Vertex AI). 
+This fork maintains full backward compatibility with the original action. All existing workflows will continue to work without changes. OAuth is an optional authentication method alongside the existing options (API key, Bedrock, Vertex AI).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 **This is a fork of the official Claude Code Action that adds support for OAuth authentication, allowing Claude Max subscribers to use their subscription in GitHub Actions.**
 
 A general-purpose [Claude Code](https://claude.ai/code) action for GitHub PRs and issues that can answer questions and implement code changes. This action listens for a trigger phrase in comments and activates Claude act on the request. It supports multiple authentication methods including:
+
 - **OAuth authentication for Claude Max subscribers** (new in this fork)
 - Anthropic direct API
 - Amazon Bedrock
@@ -73,17 +74,17 @@ jobs:
   claude-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+      - uses: t3ta/claude-code-action@main
         with:
           # Option 1: Direct API (default)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: OAuth authentication for Claude Max subscribers
           # use_oauth: "true"
           # claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
           # claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
           # claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          
+
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Optional: add custom trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -96,25 +97,25 @@ jobs:
 
 ## Inputs
 
-| Input                 | Description                                                                                                          | Required | Default   |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `anthropic_api_key`   | Anthropic API key (required for direct API, not needed for Bedrock/Vertex/OAuth)                                     | No\*     | -         |
-| `use_oauth`           | Use Claude AI OAuth authentication instead of API key (for Claude Max subscribers)                                   | No       | `false`   |
-| `claude_access_token` | Claude AI OAuth access token (required when use_oauth is true)                                                       | No       | -         |
-| `claude_refresh_token`| Claude AI OAuth refresh token (required when use_oauth is true)                                                      | No       | -         |
-| `claude_expires_at`   | Claude AI OAuth token expiration timestamp (required when use_oauth is true)                                         | No       | -         |
-| `direct_prompt`       | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                | No       | -         |
-| `timeout_minutes`     | Timeout in minutes for execution                                                                                     | No       | `30`      |
-| `github_token`        | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -         |
-| `model`               | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | -         |
-| `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | -         |
-| `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
-| `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`   |
-| `allowed_tools`       | Additional tools for Claude to use (the base GitHub tools will always be included)                                   | No       | ""        |
-| `disallowed_tools`    | Tools that Claude should never use                                                                                   | No       | ""        |
-| `custom_instructions` | Additional custom instructions to include in the prompt for Claude                                                   | No       | ""        |
-| `assignee_trigger`    | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
-| `trigger_phrase`      | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
+| Input                  | Description                                                                                                          | Required | Default   |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `anthropic_api_key`    | Anthropic API key (required for direct API, not needed for Bedrock/Vertex/OAuth)                                     | No\*     | -         |
+| `use_oauth`            | Use Claude AI OAuth authentication instead of API key (for Claude Max subscribers)                                   | No       | `false`   |
+| `claude_access_token`  | Claude AI OAuth access token (required when use_oauth is true)                                                       | No       | -         |
+| `claude_refresh_token` | Claude AI OAuth refresh token (required when use_oauth is true)                                                      | No       | -         |
+| `claude_expires_at`    | Claude AI OAuth token expiration timestamp (required when use_oauth is true)                                         | No       | -         |
+| `direct_prompt`        | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                | No       | -         |
+| `timeout_minutes`      | Timeout in minutes for execution                                                                                     | No       | `30`      |
+| `github_token`         | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -         |
+| `model`                | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | -         |
+| `anthropic_model`      | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | -         |
+| `use_bedrock`          | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
+| `use_vertex`           | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`   |
+| `allowed_tools`        | Additional tools for Claude to use (the base GitHub tools will always be included)                                   | No       | ""        |
+| `disallowed_tools`     | Tools that Claude should never use                                                                                   | No       | ""        |
+| `custom_instructions`  | Additional custom instructions to include in the prompt for Claude                                                   | No       | ""        |
+| `assignee_trigger`     | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
+| `trigger_phrase`       | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock, Vertex, or OAuth)
 
@@ -194,7 +195,7 @@ on:
       - "src/api/**/*.ts"
 
 steps:
-  - uses: Akira-Papa/claude-code-action@beta
+  - uses: t3ta/claude-code-action@main
     with:
       direct_prompt: |
         Update the API documentation in README.md to reflect
@@ -218,7 +219,7 @@ jobs:
       github.event.pull_request.user.login == 'developer1' ||
       github.event.pull_request.user.login == 'external-contributor'
     steps:
-      - uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+      - uses: t3ta/claude-code-action@main
         with:
           direct_prompt: |
             Please provide a thorough review of this pull request.
@@ -277,7 +278,7 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 **Note**: If your repository has a `.mcp.json` file in the root directory, Claude will automatically detect and use the MCP server tools defined there. However, these tools still need to be explicitly allowed via the `allowed_tools` configuration.
 
 ```yaml
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: t3ta/claude-code-action@main # Fork with OAuth support
   with:
     allowed_tools: "Bash(npm install),Bash(npm run test),Edit,Replace,NotebookEditCell"
     disallowed_tools: "TaskOutput,KillTask"
@@ -291,7 +292,7 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 Use a specific Claude model:
 
 ```yaml
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: t3ta/claude-code-action@main # Fork with OAuth support
   with:
     # model: "claude-3-5-sonnet-20241022"  # Optional: specify a different model
     # ... other inputs
@@ -320,13 +321,13 @@ Use provider-specific model names based on your chosen provider:
 
 ```yaml
 # For direct Anthropic API (default)
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: t3ta/claude-code-action@main # Fork with OAuth support
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     # ... other inputs
 
 # For OAuth authentication (Claude Max subscribers)
-- uses: Akira-Papa/claude-code-action@beta
+- uses: t3ta/claude-code-action@main
   with:
     use_oauth: "true"
     claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
@@ -335,14 +336,14 @@ Use provider-specific model names based on your chosen provider:
     # ... other inputs
 
 # For Amazon Bedrock with OIDC
-- uses: Akira-Papa/claude-code-action@beta
+- uses: t3ta/claude-code-action@main
   with:
     model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
     # ... other inputs
 
 # For Google Vertex AI with OIDC
-- uses: Akira-Papa/claude-code-action@beta
+- uses: t3ta/claude-code-action@main
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
@@ -368,7 +369,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: t3ta/claude-code-action@main # Fork with OAuth support
   with:
     model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
@@ -393,7 +394,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     app-id: ${{ secrets.APP_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-- uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+- uses: t3ta/claude-code-action@main # Fork with OAuth support
   with:
     model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: Run Claude Code
       id: claude-code
       if: steps.prepare.outputs.contains_trigger == 'true'
-      uses: Akira-Papa/claude-code-base-action@main
+      uses: t3ta/claude-code-base-action@main
       with:
         prompt_file: /tmp/claude-prompts/claude-prompt.txt
         allowed_tools: ${{ env.ALLOWED_TOOLS }}

--- a/examples/claude-auto-review.yml
+++ b/examples/claude-auto-review.yml
@@ -18,17 +18,17 @@ jobs:
           fetch-depth: 1
 
       - name: Automatic PR Review
-        uses: Akira-Papa/claude-code-action@beta
+        uses: t3ta/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: Use OAuth for Claude Max subscribers (ACTIVE)
           use_oauth: "true"
           claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
           claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
           claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          
+
           timeout_minutes: "60"
           direct_prompt: |
             Please review this pull request and provide comprehensive feedback.

--- a/examples/claude-pr-path-specific.yml
+++ b/examples/claude-pr-path-specific.yml
@@ -24,17 +24,17 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code Review
-        uses: Akira-Papa/claude-code-action@beta
+        uses: t3ta/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: Use OAuth for Claude Max subscribers (ACTIVE)
           use_oauth: "true"
           claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
           claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
           claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          
+
           timeout_minutes: "60"
           direct_prompt: |
             Please review this pull request focusing on the changed files.

--- a/examples/claude-review-from-author.yml
+++ b/examples/claude-review-from-author.yml
@@ -23,17 +23,17 @@ jobs:
           fetch-depth: 1
 
       - name: Review PR from Specific Author
-        uses: Akira-Papa/claude-code-action@beta  # Fork with OAuth support
+        uses: t3ta/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: Use OAuth for Claude Max subscribers (ACTIVE)
           use_oauth: "true"
           claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
           claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
           claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          
+
           timeout_minutes: "60"
           direct_prompt: |
             Please provide a thorough review of this pull request.

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -30,15 +30,15 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: Akira-Papa/claude-code-action@beta
+        uses: t3ta/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Option 2: Use OAuth for Claude Max subscribers (ACTIVE)
           use_oauth: "true"
           claude_access_token: ${{ secrets.CLAUDE_ACCESS_TOKEN }}
           claude_refresh_token: ${{ secrets.CLAUDE_REFRESH_TOKEN }}
           claude_expires_at: ${{ secrets.CLAUDE_EXPIRES_AT }}
-          
+
           timeout_minutes: "60"


### PR DESCRIPTION
## Summary
- `Akira-Papa/claude-code-base-action`への参照を`t3ta/claude-code-base-action`に変更
- 正しいリポジトリを参照するように修正

## 変更内容
- action.yml: ベースアクションの参照を更新
- 全てのサンプルワークフロー: t3ta/claude-code-action@mainを使用するように更新  
- README.md: 正しいアクション参照に更新
- CHANGELOG.md: 正しいフォーク情報に更新
- .github/workflows: t3taアクションを使用するように更新

## Test plan
- [x] フォーマットチェック完了
- [ ] 実際のワークフローでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)